### PR TITLE
Mexc stable connection improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>trade.wayruha</groupId>
     <artifactId>mexc-api-sdk</artifactId>
-    <version>0.0.7</version>
+    <version>0.0.8</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/trade/wayruha/mexc/MexcConfig.java
+++ b/src/main/java/trade/wayruha/mexc/MexcConfig.java
@@ -14,28 +14,29 @@ public class MexcConfig {
     private String apiSecret;
     private String passphrase;
     private String httpHost;
+    private long recvWindow;
     private String webSocketHost;
     private boolean webSocketReconnectAlways;
     private int webSocketMaxReconnectAttemptNumber;
     private int webSocketChannelKeepAlivePeriodSec;
 
     public MexcConfig() {
-        this(DEFAULT_HTTP_HOST, DEFAULT_WS_HOST, "", "", null, null);
+        this(DEFAULT_HTTP_HOST, DEFAULT_WS_HOST, "", "", null, null, null);
     }
 
     public MexcConfig(String apiKey, String apiSecret) {
-        this(DEFAULT_HTTP_HOST, DEFAULT_WS_HOST, apiKey, apiSecret, null, null);
+        this(DEFAULT_HTTP_HOST, DEFAULT_WS_HOST, apiKey, apiSecret, null, null, null);
     }
 
     public MexcConfig(String httpHost, String webSocketHost, String apiKey, String apiSecret) {
-        this(httpHost, webSocketHost, apiKey, apiSecret, null, null);
+        this(httpHost, webSocketHost, apiKey, apiSecret, null, null, null);
     }
 
     public MexcConfig(String apiKey, String apiSecret, Boolean webSocketReconnectAlways, Integer webSocketMaxReconnectAttemptNumber) {
-        this(DEFAULT_HTTP_HOST, DEFAULT_WS_HOST, apiKey, apiSecret, webSocketReconnectAlways, webSocketMaxReconnectAttemptNumber);
+        this(DEFAULT_HTTP_HOST, DEFAULT_WS_HOST, apiKey, apiSecret, null, webSocketReconnectAlways, webSocketMaxReconnectAttemptNumber);
     }
 
-    public MexcConfig(String httpHost, String webSocketHost, String apiKey, String apiSecret,
+    public MexcConfig(String httpHost, String webSocketHost, String apiKey, String apiSecret, Long connectTimeoutDefault,
                       Boolean webSocketReconnectAlways, Integer webSocketMaxReconnectAttemptNumber) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret;
@@ -47,6 +48,7 @@ public class MexcConfig {
         this.writeTimeout = GlobalParams.DEFAULT_CONNECTION_TIMEOUT;
         this.retryOnConnectionFailure = true;
         this.print = false;
+        this.recvWindow = nonNull(connectTimeoutDefault) ? connectTimeoutDefault : GlobalParams.DEFAULT_CONNECTION_TTL;
         this.webSocketReconnectAlways = nonNull(webSocketReconnectAlways) ? webSocketReconnectAlways : false;
         this.webSocketMaxReconnectAttemptNumber = nonNull(webSocketMaxReconnectAttemptNumber) ? webSocketMaxReconnectAttemptNumber : GlobalParams.WEB_SOCKET_RECONNECT_ATTEMPT_NUMBER;
         this.webSocketChannelKeepAlivePeriodSec = GlobalParams.WEB_SOCKET_CHANNEL_KEEP_ALIVE_PERIOD_SEC;

--- a/src/main/java/trade/wayruha/mexc/client/helper/HttpClientBuilder.java
+++ b/src/main/java/trade/wayruha/mexc/client/helper/HttpClientBuilder.java
@@ -34,7 +34,7 @@ public class HttpClientBuilder {
             clientBuilder.addInterceptor(loggingInterceptor);
         }
         if(isNotEmpty(config.getApiKey())) {
-            final SignatureInterceptor signatureInterceptor = new SignatureInterceptor(config.getApiKey(), config.getApiSecret());
+            final SignatureInterceptor signatureInterceptor = new SignatureInterceptor(config.getApiKey(), config.getApiSecret(), config.getRecvWindow());
             clientBuilder.addInterceptor(signatureInterceptor);
         }
         return clientBuilder.build();

--- a/src/main/java/trade/wayruha/mexc/constant/GlobalParams.java
+++ b/src/main/java/trade/wayruha/mexc/constant/GlobalParams.java
@@ -9,9 +9,9 @@ public class GlobalParams {
     /**
      * The default timeout is 30 seconds.
      */
-    public static final long DEFAULT_CONNECTION_TIMEOUT = 1000 * 30;
+    public static final long DEFAULT_CONNECTION_TIMEOUT = 30 * 1000;
     public static final String LISTEN_KEY_QUERY_PARAM = "listenKey";
-
+    public static final long DEFAULT_CONNECTION_TTL = 10 * 1000;
     public static int WEB_SOCKET_MAX_CHANNELS_PER_CONNECTION = 30;
     public static long WEB_SOCKET_RECONNECTION_DELAY_MS = 10_000;
     public static int WEB_SOCKET_CHANNEL_KEEP_ALIVE_PERIOD_SEC = 55;

--- a/src/main/java/trade/wayruha/mexc/enums/OrderStatus.java
+++ b/src/main/java/trade/wayruha/mexc/enums/OrderStatus.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum OrderStatus {
-    NEW (1),
+    NEW(1),
     FILLED(2),
     PARTIALLY_FILLED(3),
     CANCELED(4),
@@ -16,12 +16,16 @@ public enum OrderStatus {
     ERROR(999);
     private final int aliasNumber;
 
-    public static OrderStatus findByAlias(int aliasNumber){
-        return Arrays.stream(OrderStatus.values()).parallel().filter(s-> s.getAliasNumber() == aliasNumber)
+    public static OrderStatus findByAlias(int aliasNumber) {
+        return Arrays.stream(OrderStatus.values()).parallel().filter(s -> s.getAliasNumber() == aliasNumber)
                 .findFirst().orElse(null);
     }
 
-    public boolean isFinished(){
+    public boolean isFinished() {
         return this != NEW && this != PARTIALLY_FILLED;
+    }
+
+    public boolean isExecuted() {
+        return this == FILLED || this == PARTIALLY_FILLED;
     }
 }

--- a/src/main/java/trade/wayruha/mexc/enums/OrderStatus.java
+++ b/src/main/java/trade/wayruha/mexc/enums/OrderStatus.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum OrderStatus {
+    CREATED(0),
     NEW(1),
     FILLED(2),
     PARTIALLY_FILLED(3),

--- a/src/main/java/trade/wayruha/mexc/service/ServiceBase.java
+++ b/src/main/java/trade/wayruha/mexc/service/ServiceBase.java
@@ -5,9 +5,11 @@ import trade.wayruha.mexc.client.ApiClient;
 
 public abstract class ServiceBase {
     protected final ApiClient client;
+    protected final MexcConfig config;
 
     public ServiceBase(ApiClient client) {
         this.client = client;
+        this.config = client.getConfig();
     }
 
     public ServiceBase(MexcConfig config) {

--- a/src/main/java/trade/wayruha/mexc/service/TradeService.java
+++ b/src/main/java/trade/wayruha/mexc/service/TradeService.java
@@ -1,6 +1,5 @@
 package trade.wayruha.mexc.service;
 
-import org.apache.commons.lang3.StringUtils;
 import trade.wayruha.mexc.MexcConfig;
 import trade.wayruha.mexc.dto.Order;
 import trade.wayruha.mexc.dto.PostOrder;
@@ -21,9 +20,9 @@ public class TradeService extends ServiceBase {
     }
 
     public Order createNewTestOrder(PostOrder newOrder) {
-        var createdOrder = client.executeSync(api.testNewOrder(newOrder, null, null)).getData();
+        var createdOrder = client.executeSync(api.testNewOrder(newOrder)).getData();
         //mexc actually doesn't create test order till 01/05/2023. So we check to emulate answer
-        if(isNull(createdOrder) || isNull(createdOrder.getSymbol())){
+        if (isNull(createdOrder) || isNull(createdOrder.getSymbol())) {
             createdOrder = Order.builder()
                     .symbol(newOrder.getSymbol())
                     .side(newOrder.getSide())
@@ -40,16 +39,15 @@ public class TradeService extends ServiceBase {
     }
 
     public Order createNewOrder(PostOrder order) {
-        return client.executeSync(api.newOrder(order, null, null)).getData();
+        return client.executeSync(api.newOrder(order)).getData();
     }
 
     public Order cancelOrder(PostOrder order) {
         return client.executeSync(api.cancelOrder(order.getSymbol(), order.getOrderId(), order.getClientOrderId(),
-                order.getNewClientOrderId(),null, null)).getData();
+                order.getNewClientOrderId())).getData();
     }
 
-    public List<Order> cancelAllOpenOrders(List<String> symbolList) {
-        var symbols = StringUtils.join(symbolList, ",");
-        return client.executeSync(api.cancelAllOrders(symbols, null, null)).getData();
+    public List<Order> cancelAllOpenOrders(String tradingSymbol) {
+        return client.executeSync(api.cancelAllOrders(tradingSymbol)).getData();
     }
 }

--- a/src/main/java/trade/wayruha/mexc/service/WalletService.java
+++ b/src/main/java/trade/wayruha/mexc/service/WalletService.java
@@ -24,11 +24,11 @@ public class WalletService extends ServiceBase {
     }
 
     public Order getOrder(String symbol, String orderId) {
-        return this.getOrder(symbol, orderId, null, null, null);
+        return this.getOrder(symbol, orderId, null);
     }
 
-    public Order getOrder(String symbol, String orderId, String origClientOrderId, Long recvWindow, Long timestamp) {
-        return client.executeSync(api.getOrder(symbol, orderId, origClientOrderId, recvWindow, timestamp)).getData();
+    public Order getOrder(String symbol, String orderId, String origClientOrderId) {
+        return client.executeSync(api.getOrder(symbol, orderId, origClientOrderId)).getData();
     }
 
     public AccountInfo getUserAccountInfo() {

--- a/src/main/java/trade/wayruha/mexc/service/endpoint/TradeAPI.java
+++ b/src/main/java/trade/wayruha/mexc/service/endpoint/TradeAPI.java
@@ -11,20 +11,19 @@ import java.util.List;
 public interface TradeAPI {
     @POST("api/v3/order/test")
     @Headers(GlobalParams.ENDPOINT_SECURITY_SIGNED_HEADER)
-    Call<Order> testNewOrder(@Body PostOrder order, @Query("recvWindow") Integer recvWindow, @Query("timestamp") Long timestamp);
+    Call<Order> testNewOrder(@Body PostOrder order);
 
     @POST("api/v3/order")
     @Headers(GlobalParams.ENDPOINT_SECURITY_SIGNED_HEADER)
-    Call<Order> newOrder(@Body PostOrder order, @Query("recvWindow") Integer recvWindow, @Query("timestamp") Long timestamp);
+    Call<Order> newOrder(@Body PostOrder order);
 
     @DELETE("api/v3/order")
     @Headers(GlobalParams.ENDPOINT_SECURITY_SIGNED_HEADER)
     Call<Order> cancelOrder(@Query("symbol") String symbol, @Query("orderId") String orderId,
-                            @Query("origClientOrderId") String origClientOrderId, @Query("newClientOrderId") String newClientOrderId,
-                            @Query("recvWindow") Integer recvWindow, @Query("timestamp") Long timestamp);
+                            @Query("origClientOrderId") String origClientOrderId, @Query("newClientOrderId") String newClientOrderId);
 
     /** maximum input 5 symbols,separated by ",". e.g. "BTCUSDT,MXUSDT,ADAUSDT" */
     @DELETE("api/v3/openOrders")
     @Headers(GlobalParams.ENDPOINT_SECURITY_SIGNED_HEADER)
-    Call<List<Order>> cancelAllOrders(@Query("symbol") String symbolList, @Query("recvWindow") Integer recvWindow, @Query("timestamp") Long timestamp);
+    Call<List<Order>> cancelAllOrders(@Query("symbol") String symbolList);
 }

--- a/src/main/java/trade/wayruha/mexc/service/endpoint/WalletAPI.java
+++ b/src/main/java/trade/wayruha/mexc/service/endpoint/WalletAPI.java
@@ -11,7 +11,6 @@ import trade.wayruha.mexc.dto.Order;
 import java.util.List;
 
 
-
 public interface WalletAPI {
 
     @GET("api/v3/allOrders")
@@ -22,8 +21,7 @@ public interface WalletAPI {
     @GET("api/v3/order")
     @Headers(GlobalParams.ENDPOINT_SECURITY_SIGNED_HEADER)
     Call<Order> getOrder(@Query("symbol") String symbol, @Query("orderId") String orderId,
-                               @Query("origClientOrderId") String origClientOrderId, @Query("recvWindow") Long recvWindow,
-                               @Query("timestamp") Long timestamp);
+                         @Query("origClientOrderId") String origClientOrderId);
 
     @GET("/api/v3/account")
     @Headers(GlobalParams.ENDPOINT_SECURITY_SIGNED_HEADER)

--- a/src/test/java/trade/wayruha/mexc/service/TradeServiceTest.java
+++ b/src/test/java/trade/wayruha/mexc/service/TradeServiceTest.java
@@ -10,7 +10,6 @@ import trade.wayruha.mexc.enums.OrderSide;
 import trade.wayruha.mexc.enums.OrderType;
 
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.UUID;
 
 import static trade.wayruha.mexc.util.TestConstants.*;
@@ -42,7 +41,7 @@ public class TradeServiceTest {
 
     @Test
     public void test_cancelAllOpenOrders() {
-       var closedOrders = service.cancelAllOpenOrders(List.of(BTC_USD_PAIR_SYMBOL));
+       var closedOrders = service.cancelAllOpenOrders(BTC_USD_PAIR_SYMBOL);
         Assert.assertNotNull(closedOrders);
     }
 }

--- a/src/test/java/trade/wayruha/mexc/ws/PrivateWSConnectionTest.java
+++ b/src/test/java/trade/wayruha/mexc/ws/PrivateWSConnectionTest.java
@@ -24,7 +24,7 @@ public class PrivateWSConnectionTest {
     final PrivateWSSubscriptionService privateAPI = new PrivateWSSubscriptionService(apiClient);
 
     @Test
-    public void test_userSpotAccountOrder() {
+    public void test_getUserSpotAccountOrderUpdates() {
         final Callback callback = new Callback();
         final WebSocketClient ws = factory.userSpotOrdersSubscription(callback);
         sleep(GlobalParams.WEB_SOCKET_RECONNECTION_DELAY_MS);
@@ -33,7 +33,7 @@ public class PrivateWSConnectionTest {
     }
 
     @Test
-    public void test_userAccountAssetsChange() {
+    public void test_getUserAccountAssetsUpdates() {
         final Callback callback = new Callback();
         final WebSocketClient ws = factory.userAccountAssetsSubscription(callback);
         sleep(GlobalParams.WEB_SOCKET_RECONNECTION_DELAY_MS);
@@ -41,7 +41,7 @@ public class PrivateWSConnectionTest {
         assertTrue(wsResponseCounter.get() > 0);
     }
     @Test
-    public void test_userSpotDealsSubscription() {
+    public void test_getUserSpotDealsUpdates() {
         final Callback callback = new Callback();
         final WebSocketClient ws = factory.userSpotDealsSubscription(callback);
         sleep(GlobalParams.WEB_SOCKET_RECONNECTION_DELAY_MS);


### PR DESCRIPTION
- Added default connectTimeout constant in Config to specify recvWindow in REST requests. Changed mechanism to sign request with involving recvWindow parameter. Deleted parameters recvWindow & timestamp from methods that descibes REST client of MEXC (because we define and include this parameters in SignatureInterceptor.java for all ENDPOINT_SECURITY_SIGNED methods)